### PR TITLE
Use standard order for includes + Remove unnecessary boost/spirit include in format.hpp

### DIFF
--- a/src/tables/column.hpp
+++ b/src/tables/column.hpp
@@ -12,9 +12,9 @@
 #include <cstdlib>
 #include <vector>
 
+
 namespace tables
 {
-
     /// An abstract class containing only purely virtual methods. This is used
     /// as a base class for the different columns.
     class column

--- a/src/tables/const_column.cpp
+++ b/src/tables/const_column.cpp
@@ -9,7 +9,6 @@
 
 namespace tables
 {
-
     const_column::const_column(const boost::any& value, uint32_t rows)
         : m_value(value), m_rows(rows)
     {

--- a/src/tables/const_column.hpp
+++ b/src/tables/const_column.hpp
@@ -11,7 +11,6 @@
 
 namespace tables
 {
-
     /// Class for columns containing the same data for every row.
     class const_column : public column
     {

--- a/src/tables/format.hpp
+++ b/src/tables/format.hpp
@@ -5,9 +5,6 @@
 
 #pragma once
 
-#include <boost/any.hpp>
-#include <boost/spirit/home/support/detail/hold_any.hpp>
-
 #include <cassert>
 #include <cstdint>
 #include <iostream>
@@ -15,11 +12,13 @@
 #include <string>
 #include <typeinfo>
 
+#include <boost/any.hpp>
+
 #include "table.hpp"
+
 
 namespace tables
 {
-
     /// Simple helper format struct, used when printing values.
     /// The format for specific data types may be overwritten to
     /// produce a specific output.

--- a/src/tables/infix_ostream_iterator.hpp
+++ b/src/tables/infix_ostream_iterator.hpp
@@ -12,6 +12,7 @@
 #include <ostream>
 #include <iterator>
 #include <string>
+
 namespace tables
 {
     template <

--- a/src/tables/nonconst_column.cpp
+++ b/src/tables/nonconst_column.cpp
@@ -3,14 +3,13 @@
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
-#include "nonconst_column.hpp"
-
 #include <algorithm>
 #include <vector>
 
+#include "nonconst_column.hpp"
+
 namespace tables
 {
-
     nonconst_column::nonconst_column(uint32_t rows)
         : m_default_value(boost::any())
     {

--- a/src/tables/nonconst_column.hpp
+++ b/src/tables/nonconst_column.hpp
@@ -5,15 +5,14 @@
 
 #pragma once
 
-#include <boost/shared_ptr.hpp>
-
 #include <vector>
+
+#include <boost/shared_ptr.hpp>
 
 #include "column.hpp"
 
 namespace tables
 {
-
     /// Class for columns containing data for every row.
     class nonconst_column : public column
     {

--- a/src/tables/python_format.cpp
+++ b/src/tables/python_format.cpp
@@ -2,6 +2,7 @@
 // All Rights Reserved
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
+
 #include <string>
 
 #include "python_format.hpp"
@@ -12,6 +13,7 @@ namespace tables
     {
         s << "None";
     }
+
     void python_format::print(std::ostream& s, bool val) const
     {
         if (val)
@@ -24,8 +26,7 @@ namespace tables
         }
     }
 
-    void python_format::print(std::ostream& s,
-                              const std::string& val) const
+    void python_format::print(std::ostream& s, const std::string& val) const
     {
         s << "'" << val << "'";
     }

--- a/src/tables/python_format.hpp
+++ b/src/tables/python_format.hpp
@@ -13,7 +13,6 @@
 
 namespace tables
 {
-
     /// Prints to the ostream in Python format. As the Python format is based on
     /// the json one, only slight difference exists. These comes from the fact
     /// that the Python data types are different from those of Javascript

--- a/src/tables/table.hpp
+++ b/src/tables/table.hpp
@@ -5,17 +5,17 @@
 
 #pragma once
 
-#include <boost/any.hpp>
-#include <boost/shared_ptr.hpp>
-
 #include <cassert>
 #include <cstdint>
 #include <map>
 #include <string>
 #include <vector>
 
+#include <boost/any.hpp>
+#include <boost/shared_ptr.hpp>
 
 #include "column.hpp"
+
 
 namespace tables
 {

--- a/test/src/test_column.cpp
+++ b/test/src/test_column.cpp
@@ -3,16 +3,17 @@
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
-#include <gtest/gtest.h>
+#include <cstdint>
+#include <string>
+
 #include <boost/any.hpp>
 #include <boost/shared_ptr.hpp>
+
+#include <gtest/gtest.h>
 
 #include <tables/column.hpp>
 #include <tables/nonconst_column.hpp>
 #include <tables/const_column.hpp>
-
-#include <cstdint>
-#include <string>
 
 
 TEST(TestColumn, test_column_const_nonconst)
@@ -31,6 +32,7 @@ TEST(TestColumn, test_column_const_nonconst)
 class Custom
 {
 public:
+
     explicit Custom(uint32_t value)
     {
         m_value = value;
@@ -45,6 +47,7 @@ public:
     }
 
 private:
+
     uint32_t m_value;
 };
 

--- a/test/src/test_csv_format.cpp
+++ b/test/src/test_csv_format.cpp
@@ -3,16 +3,17 @@
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
-#include <gtest/gtest.h>
-
-#include <tables/csv_format.hpp>
-
 #include <cstdint>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include <gtest/gtest.h>
+
+#include <tables/csv_format.hpp>
+
 #include "format_test_helper.hpp"
+
 
 TEST(TestCsvFormat, test_csv_format)
 {

--- a/test/src/test_format.cpp
+++ b/test/src/test_format.cpp
@@ -3,14 +3,13 @@
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
+#include <cstdint>
+#include <string>
+#include <vector>
 
 #include <gtest/gtest.h>
 
 #include <tables/format.hpp>
-
-#include <cstdint>
-#include <string>
-#include <vector>
 
 #include "format_test_helper.hpp"
 

--- a/test/src/test_infix_ostream_iterator.cpp
+++ b/test/src/test_infix_ostream_iterator.cpp
@@ -3,13 +3,15 @@
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
-#include <gtest/gtest.h>
-#include <tables/infix_ostream_iterator.hpp>
-
 #include <cstdint>
 #include <string>
 #include <vector>
 #include <algorithm>
+
+#include <gtest/gtest.h>
+
+#include <tables/infix_ostream_iterator.hpp>
+
 
 template<typename T>
 void test_infix_ostream_iterator(std::vector<T> values,

--- a/test/src/test_json_format.cpp
+++ b/test/src/test_json_format.cpp
@@ -3,13 +3,14 @@
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
-#include <gtest/gtest.h>
-#include <tables/json_format.hpp>
-
 #include <cstdint>
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include <gtest/gtest.h>
+
+#include <tables/json_format.hpp>
 
 #include "format_test_helper.hpp"
 

--- a/test/src/test_python_format.cpp
+++ b/test/src/test_python_format.cpp
@@ -3,14 +3,16 @@
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
-#include <gtest/gtest.h>
-#include <tables/python_format.hpp>
-
 #include <cstdint>
 #include <vector>
 #include <string>
 
+#include <gtest/gtest.h>
+
+#include <tables/python_format.hpp>
+
 #include "format_test_helper.hpp"
+
 
 TEST(TestPythonFormat, test_python_format)
 {

--- a/test/src/test_table.cpp
+++ b/test/src/test_table.cpp
@@ -3,13 +3,16 @@
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
-#include <gtest/gtest.h>
-#include <boost/any.hpp>
-#include <tables/table.hpp>
-
 #include <cstdint>
 #include <string>
 #include <vector>
+
+#include <boost/any.hpp>
+
+#include <gtest/gtest.h>
+
+#include <tables/table.hpp>
+
 
 TEST(TestTable, test_constructor)
 {

--- a/test/tables_tests.cpp
+++ b/test/tables_tests.cpp
@@ -3,10 +3,11 @@
 //
 // Distributed under the "BSD License". See the accompanying LICENSE.rst file.
 
-#include <gtest/gtest.h>
-
 #include <cstdint>
 #include <ctime>
+
+#include <gtest/gtest.h>
+
 
 GTEST_API_ int main(int argc, char **argv)
 {

--- a/wscript
+++ b/wscript
@@ -57,7 +57,8 @@ def build(bld):
               source=bld.path.ant_glob('src/tables/*.cpp'),
               target='tables',
               export_includes=['src'],
-              use=['boost_chrono', 'boost_system', 'boost_program_options'])
+              use=['boost_includes', 'boost_chrono', 'boost_system',
+                   'boost_program_options'])
 
     if bld.is_toplevel():
         recurse_helper(bld, 'boost')


### PR DESCRIPTION
@jpihl I fixed the include order here:
1. C/C++ standard headers
2. Boost headers
3. gtest headers
4. Dependency headers (if any)
5. Internal headers of this project
We should really write this down to the style guide to avoid any confusion.

It turns out that we had a missing <iostream> include in 4.1.0, and we did not release a bugfix for that. And this was exposed by the new boost release, so all the boost dependency checks are failing for the projects that use tables 4.1.0.
We should release tables 5.0.0 and update all projects. Then I can test the new boost ;)
